### PR TITLE
Key/Value separator within each attribute

### DIFF
--- a/run_analysis.r
+++ b/run_analysis.r
@@ -20,7 +20,7 @@ products_attributes <- tbl_df(read.csv("data/attributes.csv",stringsAsFactors = 
 
 products_attributes <- products_attributes  %>%
                        filter(product_uid != 'NA') %>% #revmove null rows
-                       unite(property, c(name,value), sep = '$@$')   #combine name and values columns
+                       unite(property, c(name,value), sep = ';;')   #combine name and values columns
 # group rows with the same id
 products_attributes <- aggregate(products_attributes$property ~ products_attributes$property, by=list(products_attributes$product_uid), FUN=paste, collapse="@@@@")
 


### PR DESCRIPTION
The separator '$@$' causes trouble later on during splitting. It turns out that the dollar sign $ is a special character recognized by regular expressions and is awfully difficult to steer around.

That's why I proposed the double semi-colon ;; in its place instead.
